### PR TITLE
커스텀 배너 생성 기능

### DIFF
--- a/src/main/java/com/techeer/fmstudio/domain/banner/controller/BannerController.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/controller/BannerController.java
@@ -1,0 +1,32 @@
+package com.techeer.fmstudio.domain.banner.controller;
+
+import com.techeer.fmstudio.domain.banner.domain.Banner;
+import com.techeer.fmstudio.domain.banner.dto.BannerCreateRequest;
+import com.techeer.fmstudio.domain.banner.dto.BannerInfo;
+import com.techeer.fmstudio.domain.banner.dto.BannerMapper;
+import com.techeer.fmstudio.domain.banner.service.BannerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/banner")
+public class BannerController {
+
+    private final BannerService bannerService;
+    private final BannerMapper bannerMapper;
+
+    @PostMapping
+    public ResponseEntity<BannerInfo> create(@Valid @RequestBody BannerCreateRequest request) {
+        Banner newBanner = bannerService.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(bannerMapper.toInfo(newBanner));
+    }
+}

--- a/src/main/java/com/techeer/fmstudio/domain/banner/dao/BannerRepository.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/dao/BannerRepository.java
@@ -1,0 +1,7 @@
+package com.techeer.fmstudio.domain.banner.dao;
+
+import com.techeer.fmstudio.domain.banner.domain.Banner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+}

--- a/src/main/java/com/techeer/fmstudio/domain/banner/domain/Banner.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/domain/Banner.java
@@ -1,0 +1,102 @@
+package com.techeer.fmstudio.domain.banner.domain;
+
+import com.techeer.fmstudio.domain.member.domain.MemberEntity;
+import lombok.*;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "banner")
+public class Banner {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private MemberEntity member;
+
+    @NotBlank
+    @Column(name = "title")
+    private String title;
+
+    @NotBlank
+    @Column(name = "memo")
+    private String memo;
+
+    @NotNull
+    @Column(name = "start_at")
+    private LocalDateTime startAt;
+
+    @NotNull
+    @Column(name = "end_at")
+    private LocalDateTime endAt;
+
+    @Column(name = "is_finished")
+    private boolean isFinished;
+
+    @Column(name = "is_opened")
+    private boolean isOpened;
+
+    @OneToMany(mappedBy = "banner" , fetch = FetchType.LAZY)
+    @ToString.Exclude
+    private List<Comment> commentList;
+
+    @Column(name = "image_url")
+    @ElementCollection
+    @CollectionTable(name = "image_url",
+     joinColumns = @JoinColumn(name = "banner_id"))
+    private List<String> imageUrl;
+
+    @Column(name = "like_count")
+    private Integer likeCnt;
+
+    @Builder
+    public Banner(MemberEntity member, String title, String memo,
+                  LocalDateTime startAt, LocalDateTime endAt) {
+        this.member = member;
+        this.title = title;
+        this.memo = memo;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.isFinished = false;
+        this.isOpened = false;
+        this.likeCnt = 0;
+        this.commentList = new ArrayList<>();
+        this.imageUrl = new ArrayList<>();
+    }
+
+    public void makeFinished() {
+        this.isFinished = true;
+    }
+
+    public void makeOpened() {
+        this.isOpened = true;
+    }
+
+    public void addImageUrl(List<String> imageUrl) {
+        this.imageUrl.addAll(imageUrl);
+    }
+
+    public void addComment(List<Comment> comments) {
+        this.commentList.addAll(comments);
+    }
+
+    public void update(String title, String memo,
+                       LocalDateTime startAt, LocalDateTime endAt) {
+        this.title = title;
+        this.memo = memo;
+        this.startAt = startAt;
+        this.endAt = endAt;
+    }
+}

--- a/src/main/java/com/techeer/fmstudio/domain/banner/domain/Comment.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/domain/Comment.java
@@ -1,0 +1,35 @@
+package com.techeer.fmstudio.domain.banner.domain;
+
+import com.techeer.fmstudio.domain.member.domain.MemberEntity;
+import com.techeer.fmstudio.global.BaseEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "comment")
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_entity_id")
+    private MemberEntity writer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "banner_id")
+    private Banner banner;
+
+    @Column(name = "content")
+    private String content;
+
+    // TODO : 대댓글 컬럼 구현
+}

--- a/src/main/java/com/techeer/fmstudio/domain/banner/dto/BannerCreateRequest.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/dto/BannerCreateRequest.java
@@ -1,0 +1,40 @@
+package com.techeer.fmstudio.domain.banner.dto;
+
+import com.techeer.fmstudio.domain.banner.domain.Comment;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class BannerCreateRequest {
+
+    @NotNull(message = "Member Id of banner owner is required")
+    private Long memberId;
+
+    @NotBlank(message = "Banner title is required")
+    private String title;
+
+    @NotBlank(message = "Banner memo is required")
+    private String memo;
+
+    @NotNull(message = "Banner start date is required")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime startedAt;
+
+    @NotNull(message = "Banner end date is required")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime endAt;
+
+    private List<Comment> commentList;
+
+    private List<String> imageUrl;
+}

--- a/src/main/java/com/techeer/fmstudio/domain/banner/dto/BannerInfo.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/dto/BannerInfo.java
@@ -1,0 +1,38 @@
+package com.techeer.fmstudio.domain.banner.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.techeer.fmstudio.domain.banner.domain.Comment;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+public class BannerInfo {
+
+    private Long id;
+
+    private Long ownerId;
+
+    private String title;
+
+    private String memo;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime startAt;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime endAt;
+
+    private boolean isFinished;
+
+    private boolean isOpened;
+
+    private List<Comment> commentList;
+
+    private List<String> imageUrl;
+
+    private Integer likeCnt;
+}

--- a/src/main/java/com/techeer/fmstudio/domain/banner/dto/BannerMapper.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/dto/BannerMapper.java
@@ -1,0 +1,23 @@
+package com.techeer.fmstudio.domain.banner.dto;
+
+import com.techeer.fmstudio.domain.banner.domain.Banner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BannerMapper {
+    public BannerInfo toInfo(Banner banner) {
+        return BannerInfo.builder()
+                .id(banner.getId())
+                .ownerId(banner.getMember().getId())
+                .title(banner.getTitle())
+                .memo(banner.getMemo())
+                .startAt(banner.getStartAt())
+                .endAt(banner.getEndAt())
+                .isFinished(banner.isFinished())
+                .isOpened(banner.isOpened())
+                .commentList(banner.getCommentList())
+                .imageUrl(banner.getImageUrl())
+                .likeCnt(banner.getLikeCnt())
+                .build();
+    }
+}

--- a/src/main/java/com/techeer/fmstudio/domain/banner/exception/NotFoundBannerException.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/exception/NotFoundBannerException.java
@@ -1,0 +1,10 @@
+package com.techeer.fmstudio.domain.banner.exception;
+
+import com.techeer.fmstudio.global.error.exception.BusinessException;
+import com.techeer.fmstudio.global.error.exception.ErrorCode;
+
+public class NotFoundBannerException extends BusinessException {
+    public NotFoundBannerException() {
+        super(ErrorCode.NOT_FOUND_BANNER_ENTITY);
+    }
+}

--- a/src/main/java/com/techeer/fmstudio/domain/banner/service/BannerService.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/service/BannerService.java
@@ -1,0 +1,35 @@
+package com.techeer.fmstudio.domain.banner.service;
+
+import com.techeer.fmstudio.domain.banner.dao.BannerRepository;
+import com.techeer.fmstudio.domain.banner.domain.Banner;
+import com.techeer.fmstudio.domain.banner.dto.BannerCreateRequest;
+import com.techeer.fmstudio.domain.member.dao.MemberRepository;
+import com.techeer.fmstudio.domain.member.domain.MemberEntity;
+import com.techeer.fmstudio.domain.member.exception.NotFoundMemberException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BannerService {
+
+    private final BannerRepository bannerRepository;
+    private final MemberRepository memberRepository;
+
+    public Banner create(BannerCreateRequest request) {
+
+        MemberEntity member = memberRepository
+                .findById(request.getMemberId())
+                .orElseThrow(NotFoundMemberException::new);
+
+        Banner newBanner = Banner.builder()
+                .member(member)
+                .title(request.getTitle())
+                .memo(request.getMemo())
+                .startAt(request.getStartedAt())
+                .endAt(request.getEndAt())
+                .build();
+
+        return bannerRepository.save(newBanner);
+    }
+}

--- a/src/main/java/com/techeer/fmstudio/domain/member/dto/MemberInfo.java
+++ b/src/main/java/com/techeer/fmstudio/domain/member/dto/MemberInfo.java
@@ -6,7 +6,7 @@ import lombok.Data;
 @Data
 @Builder
 public class MemberInfo {
-
+    private Long memberId;
     private String login_id;
 
     private String login_password;

--- a/src/main/java/com/techeer/fmstudio/domain/member/dto/MemberMapper.java
+++ b/src/main/java/com/techeer/fmstudio/domain/member/dto/MemberMapper.java
@@ -28,6 +28,7 @@ public class MemberMapper {
 
     public MemberInfo toInfo(MemberEntity entity) {
         return MemberInfo.builder()
+                .memberId(entity.getId())
                 .login_id(entity.getLoginId())
                 .login_password(entity.getLoginPassword())
                 .build();

--- a/src/main/java/com/techeer/fmstudio/domain/member/exception/NotFoundMemberException.java
+++ b/src/main/java/com/techeer/fmstudio/domain/member/exception/NotFoundMemberException.java
@@ -1,0 +1,10 @@
+package com.techeer.fmstudio.domain.member.exception;
+
+import com.techeer.fmstudio.global.error.exception.BusinessException;
+import com.techeer.fmstudio.global.error.exception.ErrorCode;
+
+public class NotFoundMemberException extends BusinessException {
+    public NotFoundMemberException() {
+        super(ErrorCode.NOT_FOUND_MEMBER_ENTITY);
+    }
+}

--- a/src/main/java/com/techeer/fmstudio/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/techeer/fmstudio/global/error/exception/ErrorCode.java
@@ -10,6 +10,8 @@ public enum ErrorCode {
     // Global
     INTERNAL_SERVER_ERROR(500, "G001", "서버 오류"),
     INPUT_INVALID_VALUE(400, "G002", "잘못된 입력"),
+    NOT_FOUND_BANNER_ENTITY(400, "B001", "존재하지 않는 Banner 입니다."),
+    NOT_FOUND_MEMBER_ENTITY(400, "M001", "존재하지 않는 Member 입니다."),
     ;
 
     private final int status;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,25 @@
+spring:
+  # DB 연결
+  datasource:
+    # 설치된 H2 DB와 연결 URL
+    url: jdbc:h2:~/fmstudio-dev
+    # 접속을 위한 드라이버
+    driver-class-name: org.h2.Driver
+    # springboot 2.4 부터는 username이 꼭 있어야합니다. 없으면 에러가 발생합니다.
+    username: sa
+  jpa:
+    # JPA가 수행하는 SQL을 볼 수 있다.
+    show-sql: true
+    # 객체를 보고 자동으로 테이블 생성 여부. 생성 - create, 비생성 - none
+    # 테스트이기 때문에 create로 설정하며
+    # 실제로는 none 으로 합니다. create이면 기존의 테이블을 전부 밀어버립니다.
+    hibernate:
+      ddl-auto: create
+  # 콘솔 확인 을 위한 always
+  output:
+    ansi:
+      enabled: always
+# 파라미터 확인을 위한 trace
+logging:
+  level:
+    org.hibernate.type: trace

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,5 @@
 spring:
   profiles:
-    include: docker
+    include:
+      - docker
+      - dev


### PR DESCRIPTION
## 추가한 기능 설명

커스텀 배너 한 개 생성 기능
커스텀을 생성하기 위해선 먼저 멤버를 생성해야 함

<img width="1081" alt="스크린샷 2023-04-12 오전 2 15 49" src="https://user-images.githubusercontent.com/57928967/231239425-75799809-86d2-4368-a4f9-683d5dc85237.png">
<img width="716" alt="스크린샷 2023-04-12 오전 2 16 12" src="https://user-images.githubusercontent.com/57928967/231239512-56149a19-333b-446f-8e67-0d0a8ceda810.png">

<br>


## check list
- [ ] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [ ] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?
