### PR TITLE
커스텀 & 오피셜 배너 불러오기 (페이지네이션), 일부 기능 미구현 상태

### DIFF
--- a/src/main/java/com/techeer/fmstudio/domain/banner/controller/CustomBannerController.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/controller/CustomBannerController.java
@@ -1,17 +1,12 @@
 package com.techeer.fmstudio.domain.banner.controller;
 
 import com.techeer.fmstudio.domain.banner.domain.BannerEntity;
-import com.techeer.fmstudio.domain.banner.domain.MyBannerList;
-import com.techeer.fmstudio.domain.banner.dto.request.CustomBannerAddMyBannerRequest;
 import com.techeer.fmstudio.domain.banner.dto.request.CustomBannerCreateRequest;
 import com.techeer.fmstudio.domain.banner.dto.request.CustomBannerUpdateRequest;
 import com.techeer.fmstudio.domain.banner.dto.response.BannerInfo;
 import com.techeer.fmstudio.domain.banner.dto.mapper.BannerMapper;
-import com.techeer.fmstudio.domain.banner.dto.response.BannerPageInfo;
-import com.techeer.fmstudio.domain.banner.dto.response.MyBannerInfo;
 import com.techeer.fmstudio.domain.banner.service.CustomBannerService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,31 +18,21 @@ import javax.validation.Valid;
 @RequestMapping("api/v1/banners/custom")
 public class CustomBannerController {
 
-    private final CustomBannerService bannerService;
+    private final CustomBannerService customBannerService;
     private final BannerMapper bannerMapper;
 
     @PostMapping
     public ResponseEntity<BannerInfo> create(@Valid @RequestBody CustomBannerCreateRequest request) {
-        BannerEntity newBanner = bannerService.create(request);
+        BannerEntity newBanner = customBannerService.create(request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(bannerMapper.toBannerInfo(newBanner));
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<BannerInfo> getOne(@PathVariable Long id){
-        BannerEntity foundBanner = bannerService.getOne(id);
+        BannerEntity foundBanner = customBannerService.getOne(id);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(bannerMapper.toBannerInfo(foundBanner));
-    }
-
-    @GetMapping("/page")
-    public ResponseEntity<BannerPageInfo> getWholeBannerByPagination(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "6") int size
-    ){
-        BannerPageInfo foundBannerList = bannerService.getWholeBannerByPagination(page,size);
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(foundBannerList);
     }
 
     @PatchMapping("/{id}")
@@ -55,30 +40,14 @@ public class CustomBannerController {
             @Valid @RequestBody CustomBannerUpdateRequest request,
             @PathVariable Long id
             ){
-        String result = bannerService.update(request, id);
+        String result = customBannerService.update(request, id);
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<String> delete(@PathVariable Long id) {
-        BannerEntity deletedBanner = bannerService.delete(id);
+        BannerEntity deletedBanner = customBannerService.delete(id);
         return ResponseEntity.status(HttpStatus.OK)
                 .body("배너 id " + deletedBanner.getId().toString() + "가 삭제 되었습니다.");
-    }
-
-    @PostMapping("mybanners/{id}")
-    public ResponseEntity<MyBannerInfo> addMyBannerList(
-            @Valid @RequestBody CustomBannerAddMyBannerRequest request,
-            @PathVariable Long id
-    ){
-
-        MyBannerList myBannerList = bannerService.addMyBanner(request, id);
-        MyBannerInfo myBannerInfo = MyBannerInfo.builder()
-                .nickname(myBannerList.getMember().getNickname())
-                .bannerId(myBannerList.getBanner().getId())
-                .build();
-
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(myBannerInfo);
     }
 }

--- a/src/main/java/com/techeer/fmstudio/domain/banner/controller/CustomBannerController.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/controller/CustomBannerController.java
@@ -7,9 +7,11 @@ import com.techeer.fmstudio.domain.banner.dto.request.CustomBannerCreateRequest;
 import com.techeer.fmstudio.domain.banner.dto.request.CustomBannerUpdateRequest;
 import com.techeer.fmstudio.domain.banner.dto.response.BannerInfo;
 import com.techeer.fmstudio.domain.banner.dto.mapper.BannerMapper;
+import com.techeer.fmstudio.domain.banner.dto.response.BannerPageInfo;
 import com.techeer.fmstudio.domain.banner.dto.response.MyBannerInfo;
 import com.techeer.fmstudio.domain.banner.service.CustomBannerService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -28,14 +30,24 @@ public class CustomBannerController {
     public ResponseEntity<BannerInfo> create(@Valid @RequestBody CustomBannerCreateRequest request) {
         BannerEntity newBanner = bannerService.create(request);
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(bannerMapper.toInfo(newBanner));
+                .body(bannerMapper.toBannerInfo(newBanner));
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<BannerInfo> getOne(@PathVariable Long id){
         BannerEntity foundBanner = bannerService.getOne(id);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(bannerMapper.toInfo(foundBanner));
+                .body(bannerMapper.toBannerInfo(foundBanner));
+    }
+
+    @GetMapping("/page")
+    public ResponseEntity<BannerPageInfo> getWholeBannerByPagination(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "6") int size
+    ){
+        BannerPageInfo foundBannerList = bannerService.getWholeBannerByPagination(page,size);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(foundBannerList);
     }
 
     @PatchMapping("/{id}")

--- a/src/main/java/com/techeer/fmstudio/domain/banner/controller/WholeBannerController.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/controller/WholeBannerController.java
@@ -1,0 +1,49 @@
+package com.techeer.fmstudio.domain.banner.controller;
+
+import com.techeer.fmstudio.domain.banner.domain.MyBannerList;
+import com.techeer.fmstudio.domain.banner.dto.mapper.BannerMapper;
+import com.techeer.fmstudio.domain.banner.dto.request.CustomBannerAddMyBannerRequest;
+import com.techeer.fmstudio.domain.banner.dto.response.BannerPageInfo;
+import com.techeer.fmstudio.domain.banner.dto.response.MyBannerInfo;
+import com.techeer.fmstudio.domain.banner.service.WholeBannerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/banners")
+public class WholeBannerController {
+
+    private final WholeBannerService wholeBannerService;
+    private final BannerMapper bannerMapper;
+
+    @GetMapping("/page")
+    public ResponseEntity<BannerPageInfo> getWholeBannerByPagination(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "6") int size
+    ){
+        BannerPageInfo foundBannerList = wholeBannerService.getWholeBannerByPagination(page,size);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(foundBannerList);
+    }
+
+    @PostMapping("mybanners/{id}")
+    public ResponseEntity<MyBannerInfo> addBannerToMyList(
+            @Valid @RequestBody CustomBannerAddMyBannerRequest request,
+            @PathVariable Long id
+    ){
+
+        MyBannerList myBannerList = wholeBannerService.addMyBanner(request, id);
+        MyBannerInfo myBannerInfo = MyBannerInfo.builder()
+                .nickname(myBannerList.getMember().getNickname())
+                .bannerId(myBannerList.getBanner().getId())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(myBannerInfo);
+    }
+}

--- a/src/main/java/com/techeer/fmstudio/domain/banner/dao/BannerRepository.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/dao/BannerRepository.java
@@ -20,4 +20,6 @@ public interface BannerRepository extends JpaRepository<BannerEntity, Long> {
             "ORDER BY b.createdAt asc")
     Page<BannerEntity> findBannerByTypeWithPagination(Pageable pageable, @Param("type") BannerType type);
 
+    @Query("SELECT b FROM BannerEntity b WHERE b.isActive = true ORDER BY b.createdAt asc")
+    Page<BannerEntity> findWholeBannerWithPagination(Pageable pageable);
 }

--- a/src/main/java/com/techeer/fmstudio/domain/banner/domain/BannerEntity.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/domain/BannerEntity.java
@@ -1,5 +1,6 @@
 package com.techeer.fmstudio.domain.banner.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.techeer.fmstudio.domain.member.domain.MemberEntity;
 import com.techeer.fmstudio.global.BaseEntity;
 import lombok.*;
@@ -29,6 +30,7 @@ public class BannerEntity extends BaseEntity {
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
+    @JsonIgnore
     private MemberEntity member;
 
     @NotBlank
@@ -48,9 +50,10 @@ public class BannerEntity extends BaseEntity {
     private LocalDateTime endAt;
 
     @Column(name = "is_finished")
-    private boolean isFinished;
+    private Boolean isFinished;
 
     @OneToMany(mappedBy = "banner" , fetch = FetchType.LAZY)
+    @JsonIgnore
     private List<CommentEntity> commentList;
 
     @Column(name = "image_url")

--- a/src/main/java/com/techeer/fmstudio/domain/banner/dto/mapper/BannerMapper.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/dto/mapper/BannerMapper.java
@@ -2,24 +2,41 @@ package com.techeer.fmstudio.domain.banner.dto.mapper;
 
 import com.techeer.fmstudio.domain.banner.domain.BannerEntity;
 import com.techeer.fmstudio.domain.banner.dto.response.BannerInfo;
+import com.techeer.fmstudio.domain.banner.dto.response.BannerPageInfo;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 public class BannerMapper {
-    public BannerInfo toInfo(BannerEntity banner) {
+    public BannerInfo toBannerInfo(BannerEntity banner) {
+
+
         return BannerInfo.builder()
                 .type(banner.getBannerType())
-                .bannerId(banner.getId())
-                .nickname(banner.getMember().getNickname())
+                .id(banner.getId())
+                .writer(banner.getMember().getNickname())
                 .title(banner.getTitle())
                 .memo(banner.getMemo())
                 .startAt(banner.getStartAt())
                 .endAt(banner.getEndAt())
-                .isFinished(banner.isFinished())
-                .commentList(banner.getCommentList())
+                .isFinished(banner.getIsFinished())
                 .imageUrl(banner.getImageUrl())
                 .likeCnt(banner.getLikeCnt())
                 .readCnt(banner.getReadCnt())
+                .build();
+    }
+
+    public BannerPageInfo mapEntityToBannerPageInfo(Page<BannerEntity> bannerEntityPage, int page, int size){
+        List<BannerInfo> bannerInfoList =
+                bannerEntityPage.stream().map(this::toBannerInfo).toList();
+        return BannerPageInfo.builder()
+                .totalPages(bannerEntityPage.getTotalPages())
+                .totalElements(bannerEntityPage.getTotalElements())
+                .size(size)
+                .page(page)
+                .content(bannerInfoList)
                 .build();
     }
 }

--- a/src/main/java/com/techeer/fmstudio/domain/banner/dto/response/BannerInfo.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/dto/response/BannerInfo.java
@@ -2,7 +2,6 @@ package com.techeer.fmstudio.domain.banner.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.techeer.fmstudio.domain.banner.domain.BannerType;
-import com.techeer.fmstudio.domain.banner.domain.CommentEntity;
 import lombok.Builder;
 import lombok.Data;
 
@@ -15,9 +14,9 @@ public class BannerInfo {
 
     private BannerType type;
 
-    private Long bannerId;
+    private Long id;
 
-    private String nickname;
+    private String writer;
 
     private String title;
 
@@ -29,17 +28,15 @@ public class BannerInfo {
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime endAt;
 
-    private List<CommentEntity> commentList;
-
     private List<String> imageUrl;
 
     private Integer likeCnt;
 
-    private boolean isFinished;
+    private Boolean isFinished;
 
-    private boolean isLiked;
+    private Boolean isLiked;
 
-    private boolean isIncluded;
+    private Boolean isIncluded;
 
     private Integer readCnt;
 }

--- a/src/main/java/com/techeer/fmstudio/domain/banner/dto/response/BannerPageInfo.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/dto/response/BannerPageInfo.java
@@ -1,0 +1,18 @@
+package com.techeer.fmstudio.domain.banner.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class BannerPageInfo {
+    private int totalPages;
+
+    private long totalElements;
+    private int size;
+    private int page;
+
+    private List<BannerInfo> content;
+}

--- a/src/main/java/com/techeer/fmstudio/domain/banner/service/CustomBannerService.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/service/CustomBannerService.java
@@ -4,19 +4,14 @@ import com.techeer.fmstudio.domain.banner.dao.BannerRepository;
 import com.techeer.fmstudio.domain.banner.dao.MyBannerListRepository;
 import com.techeer.fmstudio.domain.banner.domain.BannerEntity;
 import com.techeer.fmstudio.domain.banner.domain.BannerType;
-import com.techeer.fmstudio.domain.banner.domain.MyBannerList;
 import com.techeer.fmstudio.domain.banner.dto.mapper.BannerMapper;
-import com.techeer.fmstudio.domain.banner.dto.request.CustomBannerAddMyBannerRequest;
 import com.techeer.fmstudio.domain.banner.dto.request.CustomBannerCreateRequest;
 import com.techeer.fmstudio.domain.banner.dto.request.CustomBannerUpdateRequest;
-import com.techeer.fmstudio.domain.banner.dto.response.BannerPageInfo;
 import com.techeer.fmstudio.domain.banner.exception.NotFoundBannerException;
 import com.techeer.fmstudio.domain.member.dao.MemberRepository;
 import com.techeer.fmstudio.domain.member.domain.MemberEntity;
 import com.techeer.fmstudio.domain.member.exception.NotFoundMemberException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -58,13 +53,6 @@ public class CustomBannerService {
                 .orElseThrow(NotFoundBannerException::new);
     }
 
-    @Transactional(readOnly = true)
-    public BannerPageInfo getWholeBannerByPagination(int page, int size){
-        PageRequest pageRequest = PageRequest.of(page, size);
-        Page<BannerEntity> pageResult = bannerRepository.findWholeBannerWithPagination(pageRequest);
-        return bannerMapper.mapEntityToBannerPageInfo(pageResult, page, size);
-    }
-
     public String update(CustomBannerUpdateRequest request, Long id) {
         BannerEntity foundBanner = bannerRepository.findById(id)
                 .orElseThrow(NotFoundBannerException::new);
@@ -87,15 +75,5 @@ public class CustomBannerService {
         foundBanner.deleteBanner();
 
         return foundBanner;
-    }
-
-    public MyBannerList addMyBanner(CustomBannerAddMyBannerRequest request, Long bannerId){
-        MemberEntity member = memberRepository.findMemberEntityByNickname(request.getNickname()).orElseThrow(NotFoundMemberException::new);
-        BannerEntity banner = bannerRepository.findById(bannerId).orElseThrow(NotFoundBannerException::new);
-        MyBannerList myBannerList = MyBannerList.builder()
-                .banner(banner)
-                .member(member)
-                .build();
-        return myBannerListRepository.save(myBannerList);
     }
 }

--- a/src/main/java/com/techeer/fmstudio/domain/banner/service/CustomBannerService.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/service/CustomBannerService.java
@@ -5,14 +5,18 @@ import com.techeer.fmstudio.domain.banner.dao.MyBannerListRepository;
 import com.techeer.fmstudio.domain.banner.domain.BannerEntity;
 import com.techeer.fmstudio.domain.banner.domain.BannerType;
 import com.techeer.fmstudio.domain.banner.domain.MyBannerList;
+import com.techeer.fmstudio.domain.banner.dto.mapper.BannerMapper;
 import com.techeer.fmstudio.domain.banner.dto.request.CustomBannerAddMyBannerRequest;
 import com.techeer.fmstudio.domain.banner.dto.request.CustomBannerCreateRequest;
 import com.techeer.fmstudio.domain.banner.dto.request.CustomBannerUpdateRequest;
+import com.techeer.fmstudio.domain.banner.dto.response.BannerPageInfo;
 import com.techeer.fmstudio.domain.banner.exception.NotFoundBannerException;
 import com.techeer.fmstudio.domain.member.dao.MemberRepository;
 import com.techeer.fmstudio.domain.member.domain.MemberEntity;
 import com.techeer.fmstudio.domain.member.exception.NotFoundMemberException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +27,8 @@ public class CustomBannerService {
     private final BannerRepository bannerRepository;
     private final MemberRepository memberRepository;
     private final MyBannerListRepository myBannerListRepository;
+
+    private final BannerMapper bannerMapper;
 
     public BannerEntity create(CustomBannerCreateRequest request) {
 
@@ -50,6 +56,13 @@ public class CustomBannerService {
     public BannerEntity getOne(Long id){
         return bannerRepository.findById(id)
                 .orElseThrow(NotFoundBannerException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public BannerPageInfo getWholeBannerByPagination(int page, int size){
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<BannerEntity> pageResult = bannerRepository.findWholeBannerWithPagination(pageRequest);
+        return bannerMapper.mapEntityToBannerPageInfo(pageResult, page, size);
     }
 
     public String update(CustomBannerUpdateRequest request, Long id) {

--- a/src/main/java/com/techeer/fmstudio/domain/banner/service/WholeBannerService.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/service/WholeBannerService.java
@@ -1,0 +1,47 @@
+package com.techeer.fmstudio.domain.banner.service;
+
+
+import com.techeer.fmstudio.domain.banner.dao.BannerRepository;
+import com.techeer.fmstudio.domain.banner.dao.MyBannerListRepository;
+import com.techeer.fmstudio.domain.banner.domain.BannerEntity;
+import com.techeer.fmstudio.domain.banner.domain.MyBannerList;
+import com.techeer.fmstudio.domain.banner.dto.mapper.BannerMapper;
+import com.techeer.fmstudio.domain.banner.dto.request.CustomBannerAddMyBannerRequest;
+import com.techeer.fmstudio.domain.banner.dto.response.BannerPageInfo;
+import com.techeer.fmstudio.domain.banner.exception.NotFoundBannerException;
+import com.techeer.fmstudio.domain.member.dao.MemberRepository;
+import com.techeer.fmstudio.domain.member.domain.MemberEntity;
+import com.techeer.fmstudio.domain.member.exception.NotFoundMemberException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class WholeBannerService {
+
+    private final BannerRepository bannerRepository;
+    private final MemberRepository memberRepository;
+    private final MyBannerListRepository myBannerListRepository;
+
+    private final BannerMapper bannerMapper;
+
+    @Transactional(readOnly = true)
+    public BannerPageInfo getWholeBannerByPagination(int page, int size){
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<BannerEntity> pageResult = bannerRepository.findWholeBannerWithPagination(pageRequest);
+        return bannerMapper.mapEntityToBannerPageInfo(pageResult, page, size);
+    }
+
+    public MyBannerList addMyBanner(CustomBannerAddMyBannerRequest request, Long bannerId){
+        MemberEntity member = memberRepository.findMemberEntityByNickname(request.getNickname()).orElseThrow(NotFoundMemberException::new);
+        BannerEntity banner = bannerRepository.findById(bannerId).orElseThrow(NotFoundBannerException::new);
+        MyBannerList myBannerList = MyBannerList.builder()
+                .banner(banner)
+                .member(member)
+                .build();
+        return myBannerListRepository.save(myBannerList);
+    }
+}


### PR DESCRIPTION
## 추가한 기능 설명

### 커스텀 & 오피셜 배너 불러오기 기능
<img width="1086" alt="스크린샷 2023-04-27 오전 5 03 56" src="https://user-images.githubusercontent.com/57928967/234689717-84b1a12e-83cd-4552-84e9-839b0e32397a.png">


### 미구현 기능 목록
* 좋아요 기능 (likeCnt)
* 완료 기능 (isFinished)
* 내 달력에 포함 여부 확인 기능 (isIncluded)
* 조회수 기능 (readCnt)

## 주의
첫 번째 페이지가 0부터 시작함

<br>


## check list
- [ ] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [ ] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?
