### PR TITLE
커스텀 배너 불러오기 (페이지네이션), 일부 기능 미구현

### DIFF
--- a/src/main/java/com/techeer/fmstudio/domain/banner/controller/CustomBannerController.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/controller/CustomBannerController.java
@@ -5,6 +5,7 @@ import com.techeer.fmstudio.domain.banner.dto.request.CustomBannerCreateRequest;
 import com.techeer.fmstudio.domain.banner.dto.request.CustomBannerUpdateRequest;
 import com.techeer.fmstudio.domain.banner.dto.response.BannerInfo;
 import com.techeer.fmstudio.domain.banner.dto.mapper.BannerMapper;
+import com.techeer.fmstudio.domain.banner.dto.response.BannerPageInfo;
 import com.techeer.fmstudio.domain.banner.service.CustomBannerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -33,6 +34,16 @@ public class CustomBannerController {
         BannerEntity foundBanner = customBannerService.getOne(id);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(bannerMapper.toBannerInfo(foundBanner));
+    }
+
+    @GetMapping("/page")
+    public ResponseEntity<BannerPageInfo> getCustomBannerByPagination(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "6") int size
+    ){
+        BannerPageInfo foundBannerList = customBannerService.getCustomBannerByPagination(page,size);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(foundBannerList);
     }
 
     @PatchMapping("/{id}")

--- a/src/main/java/com/techeer/fmstudio/domain/banner/service/CustomBannerService.java
+++ b/src/main/java/com/techeer/fmstudio/domain/banner/service/CustomBannerService.java
@@ -1,17 +1,19 @@
 package com.techeer.fmstudio.domain.banner.service;
 
 import com.techeer.fmstudio.domain.banner.dao.BannerRepository;
-import com.techeer.fmstudio.domain.banner.dao.MyBannerListRepository;
 import com.techeer.fmstudio.domain.banner.domain.BannerEntity;
 import com.techeer.fmstudio.domain.banner.domain.BannerType;
 import com.techeer.fmstudio.domain.banner.dto.mapper.BannerMapper;
 import com.techeer.fmstudio.domain.banner.dto.request.CustomBannerCreateRequest;
 import com.techeer.fmstudio.domain.banner.dto.request.CustomBannerUpdateRequest;
+import com.techeer.fmstudio.domain.banner.dto.response.BannerPageInfo;
 import com.techeer.fmstudio.domain.banner.exception.NotFoundBannerException;
 import com.techeer.fmstudio.domain.member.dao.MemberRepository;
 import com.techeer.fmstudio.domain.member.domain.MemberEntity;
 import com.techeer.fmstudio.domain.member.exception.NotFoundMemberException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,8 +23,6 @@ public class CustomBannerService {
 
     private final BannerRepository bannerRepository;
     private final MemberRepository memberRepository;
-    private final MyBannerListRepository myBannerListRepository;
-
     private final BannerMapper bannerMapper;
 
     public BannerEntity create(CustomBannerCreateRequest request) {
@@ -51,6 +51,13 @@ public class CustomBannerService {
     public BannerEntity getOne(Long id){
         return bannerRepository.findById(id)
                 .orElseThrow(NotFoundBannerException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public BannerPageInfo getCustomBannerByPagination(int page, int size){
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<BannerEntity> pageResult = bannerRepository.findBannerByTypeWithPagination(pageRequest, BannerType.CUSTOM);
+        return bannerMapper.mapEntityToBannerPageInfo(pageResult, page, size);
     }
 
     public String update(CustomBannerUpdateRequest request, Long id) {


### PR DESCRIPTION
## 추가한 기능 설명

### 커스텀 배너 불러오기 (페이지네이션)

<img width="1079" alt="스크린샷 2023-04-27 오전 5 07 36" src="https://user-images.githubusercontent.com/57928967/234690530-0b37dabb-5fa6-46c7-8671-36e02307146b.png">

### 미구현 기능 목록
* 좋아요 기능 (likeCnt)
* 완료 기능 (isFinished)
* 내 달력에 포함 여부 확인 기능 (isIncluded)
* 조회수 기능 (readCnt)

## 주의
첫 번째 페이지가 0부터 시작함
<br>


## check list
- [ ] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [ ] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?
