### PR TITLE
feat : 달력에 필요한 직전 달 일정, 다음 달 일정 가져오는 기능

### DIFF
--- a/src/main/java/com/techeer/fmstudio/domain/task/controller/TaskController.java
+++ b/src/main/java/com/techeer/fmstudio/domain/task/controller/TaskController.java
@@ -61,6 +61,24 @@ public class TaskController {
                 .body(taskService.getPrivateTaskAndSharedTask(memberId, year, month));
     }
 
+    @GetMapping("/previous-month-tasks/list")
+    @CrossOrigin(origins = "http://localhost:3000", allowedHeaders = "*")
+    public ResponseEntity<List<TaskResponse>> getPreviousMonthTask(@Valid @RequestParam String memberId,
+                                                                          @Valid @RequestParam Integer year,
+                                                                          @Valid @RequestParam Integer month) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(taskService.getPreviousMonthTask(memberId, year, month));
+    }
+
+    @GetMapping("/next-month-tasks/list")
+    @CrossOrigin(origins = "http://localhost:3000", allowedHeaders = "*")
+    public ResponseEntity<List<TaskResponse>> getNextMonthTask(@Valid @RequestParam String memberId,
+                                                               @Valid @RequestParam Integer year,
+                                                               @Valid @RequestParam Integer month) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(taskService.getNextMonthTask(memberId, year, month));
+    }
+
     @GetMapping("/tasks/privacy/list")
     @CrossOrigin(origins = "http://localhost:3000", allowedHeaders = "*")
     public ResponseEntity<List<TaskResponse>> getWriterTaskByYearAndMonth(@Valid @RequestParam String memberId,

--- a/src/main/java/com/techeer/fmstudio/domain/task/dao/TaskRepository.java
+++ b/src/main/java/com/techeer/fmstudio/domain/task/dao/TaskRepository.java
@@ -4,6 +4,7 @@ import com.techeer.fmstudio.domain.task.domain.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -24,4 +25,16 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
             "and t.isActive = true " +
             "order by t.startAt")
     Optional<Task> findTaskByIdAndStartAtOrOrderByStartAt(Long id, Integer year, Integer month);
+
+    @Query(nativeQuery = true, value = "select * from task where writer = :memberId " +
+            "and is_active = true " +
+            "and start_at between :lastDayOfMonth and DATE_ADD(:lastDayOfMonth, INTERVAL :remainingDay DAY) " +
+            "order by start_at asc")
+    List<Task> findTaskOfAfterMonth(String memberId, Date lastDayOfMonth, int remainingDay);
+
+    @Query(nativeQuery = true, value = "select * from task where writer = :memberId " +
+            "and is_active = true " +
+            "and start_at between DATE_SUB(:firstDateOfMonth, INTERVAL :remainingDay DAY) and :firstDateOfMonth " +
+            "order by start_at asc")
+    List<Task> findTaskOfBeforeMonth(String memberId, Date firstDateOfMonth, int remainingDay);
 }


### PR DESCRIPTION
## 추가한 기능 설명

- native query의 DATE_ADD, DATE_SUB을 이용해 날짜 차이를 계산해서 일정을 가져옵니다.
- DATE_ADD, DATE_SUB는 MySQL 기준으로 사용할 수 있는 함수라서 다른 DB를 사용할 때 문법 주의해야 합니다.
- 달력의 직전 달 일정, 다음 달 일정이 따로 필요한 경우가 있을 수도 있어서 각각 API도 추가했습니다.
- MySQL의 DATE_ADD 함수는 주어진 날짜의 시, 분, 초 + 더할 날짜이므로 날짜의 시, 분, 초에 따라 일정이 검색되지 않을 수 있으니 주의해야합니다.
   - 이걸 해결하기 위해 LocalDate형식을 Date 형식으로 형변환했습니다. LocalDate는 연, 월, 일까지만 나오므로 시, 분, 초를 고려하지 않아도 됩니다.

![image](https://github.com/Techeer-FM-Studio/backend/assets/70627982/f0db406c-3ed3-4fba-bb86-d65ccae01e14)
2023년 5월 기준으로 달력에 보이는 4월 30일 일정 가져온거 확인 완료 (시작일 기준)

![image](https://github.com/Techeer-FM-Studio/backend/assets/70627982/e7c42583-c936-41e7-b2ff-b87e812d24d3)
2023년 5월 기준으로 달력에 보이는 6월 1, 2, 3일 일정 가져온거 확인 완료 (시작일 기준)

<br>


## check list
- [ ] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [ ] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?
